### PR TITLE
Return empty Promises.

### DIFF
--- a/lib/flux.js
+++ b/lib/flux.js
@@ -58,7 +58,16 @@ const NanoFlux = {
 
         // The public action function gets bound to the custom dispatch function.
         actions[actionsKey][actionKey] = (...args) => {
-          actionCreators[actionKey](dispatch, ...args);
+          const maybePromise = actionCreators[actionKey](dispatch, ...args);
+          if (maybePromise instanceof Promise) {
+            // strip data and return a "naked" promise
+            return new Promise((resolve, reject) => {
+              maybePromise.then(() => resolve()).catch(() => reject(new Error('Action failed')));
+            });
+          } else {
+            // just insta resolve a fake promise
+            return new Promise((resolve, reject) => resolve());
+          }
         };
       });
     };

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -59,7 +59,7 @@ const NanoFlux = {
         // The public action function gets bound to the custom dispatch function.
         actions[actionsKey][actionKey] = (...args) => {
           const maybePromise = actionCreators[actionKey](dispatch, ...args);
-          if (maybePromise instanceof Promise) {
+          if (maybePromise && typeof maybePromise.then === 'function') {
             // strip data and return a "naked" promise
             return new Promise((resolve, reject) => {
               maybePromise.then(() => resolve()).catch(() => reject(new Error('Action failed')));

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -62,7 +62,12 @@ const NanoFlux = {
           if (maybePromise && typeof maybePromise.then === 'function') {
             // strip data and return a "naked" promise
             return new Promise((resolve, reject) => {
-              maybePromise.then(() => resolve()).catch(() => reject(new Error('Action failed')));
+              maybePromise.then(() => {
+                resolve();
+              }).catch((err) => {
+                fluxEmitter.emit('error', err);
+                reject(new Error('Action failed'));
+              });
             });
           } else {
             // just insta resolve a fake promise

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-flux",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Tiny, simple wrapper around Facebook's Flux library.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The only information sent past this event horizon is a single bit - success true/false. Helpful in those pesky situations where you need to kick off a follow up action or react to a completed event.
