### PR TITLE
allow action creators to dispatch to differently named actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Just a tiny, simple wrapper around Facebook's flux dispatcher.
 
 ### Implicit actions
 
-If your action is just passing through to the store, you can forget all the
-boilerplate!
+If all your actions are just passing through to the store, you can forget all the
+boilerplate! This is great for testing a store.
 
 ```js
 import Flux from 'nano-flux';
@@ -65,7 +65,8 @@ flux.actions.message.addMessage('Hello, world!');
 ### Explicit actions
 
 If your action needs to do a bit of work before dispatching, it's easy to add
-explict action creators.
+explict action creators. Note that if you define any action creators, no
+implicit ones will be created.
 
 ```js
 import Flux from 'nano-flux';
@@ -197,11 +198,11 @@ const messageActions = {
     SomeDataService.addMessage(content)
       .then((result) => {
         // Dispatch for success.
-        dispatch.actions.addMessageDone(cid, result.id);
+        dispatch.to.addMessageDone(cid, result.id);
       })
       .catch((error) => {
         // Dispatch for failure.
-        dispatch.actions.addMessageFail(cid, error);
+        dispatch.to.addMessageFail(cid, error);
       });
   }
 };

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -66,9 +66,24 @@ const NanoFlux = {
         dispatch.actions = actions[actionsKey];
         dispatch.to = dispatchers[actionsKey];
 
+        let actionCreator = actionCreators[actionKey];
+        // Allow shortcut of true to mean self-dispatch.
+        if (actionCreator === true) {
+          actionCreator = (myDispatch, ...args) => {
+            myDispatch.to[actionKey](...args);
+          };
+        }
+        // Allow shortcut of string to mean dispatch to that action.
+        if (typeof actionCreator === 'string') {
+          const delegateActionName = actionCreator;
+          actionCreator = (myDispatch, ...args) => {
+            myDispatch.to[delegateActionName](...args);
+          };
+        }
+
         // The public action function gets bound to the custom dispatch function.
         actions[actionsKey][actionKey] = (...args) => {
-          actionCreators[actionKey](dispatch, ...args);
+          actionCreator(dispatch, ...args);
         };
       });
     };
@@ -155,13 +170,20 @@ const NanoFlux = {
     const addPlaceholderActions = (storeKey, handlers, actionsKey) => {
       actionsKey = actionsKey || storeKey;
 
+      let canCreatePlaceholderActions = false;
+
+      if (!actions[actionsKey]) {
+        dispatchers[actionsKey] = {};
+        actions[actionsKey] = {};
+        // Only create placeholder actions if no actions were created for this namespace.
+        canCreatePlaceholderActions = true;
+      }
+
       Object.keys(handlers).forEach((key) => {
         if (typeof handlers[key] === 'function') {
-          if (!actions[actionsKey]) {
-            actions[actionsKey] = {};
-            dispatchers[actionsKey] = {};
-          }
-          if (!actions[actionsKey][key]) {
+
+          // Make sure a dispatcher exists for this action.
+          if (!dispatchers[actionsKey][key]) {
             const dispatch = (...args) => {
               fluxDispatch({
                 actionsKey: actionsKey,
@@ -170,9 +192,16 @@ const NanoFlux = {
               });
             };
             dispatchers[actionsKey][key] = dispatch;
-            actions[actionsKey][key] = (...args) => {
-              dispatch(...args);
-            };
+          }
+
+          // Create stub action if allowed.
+          if (canCreatePlaceholderActions) {
+            if (!actions[actionsKey][key]) {
+              const dispatch = dispatchers[actionsKey][key];
+              actions[actionsKey][key] = (...args) => {
+                dispatch(...args);
+              };
+            }
           }
         } else if (typeof handlers[key] === 'object') {
           // If we have an object, the key refers to a different store, so

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -14,6 +14,8 @@ const NanoFlux = {
     const stores = {};
     // Registry of action creators.
     const actions = {};
+    // Registry of dispatchers.
+    const dispatchers = {};
     // Emitter for listening to flux events.
     const fluxEmitter = new EventEmitter();
 
@@ -34,8 +36,12 @@ const NanoFlux = {
         };
       }
 
-      // Add the namespace to the registry.
+      // Add the namespace to the actions registry.
       actions[actionsKey] = {};
+
+      // Create a map of all dispatchers for this namespace in case an action
+      // creator needs to dispatch a differently named action.
+      dispatchers[actionsKey] = {};
 
       // Call the setup function to get the action creator functions.
       const actionCreators = setupFn(actions[actionsKey]);
@@ -52,9 +58,13 @@ const NanoFlux = {
           });
         };
 
-        // Hang other actions off this dispatch functions in case the action
+        // Add this dispatcher to the list of dispatchers for this namespace.
+        dispatchers[actionsKey][actionKey] = dispatch;
+
+        // Hang other actions off this dispatch function in case the action
         // creator needs to dispatch other actions.
         dispatch.actions = actions[actionsKey];
+        dispatch.to = dispatchers[actionsKey];
 
         // The public action function gets bound to the custom dispatch function.
         actions[actionsKey][actionKey] = (...args) => {
@@ -149,14 +159,19 @@ const NanoFlux = {
         if (typeof handlers[key] === 'function') {
           if (!actions[actionsKey]) {
             actions[actionsKey] = {};
+            dispatchers[actionsKey] = {};
           }
           if (!actions[actionsKey][key]) {
-            actions[actionsKey][key] = (...args) => {
+            const dispatch = (...args) => {
               fluxDispatch({
                 actionsKey: actionsKey,
                 actionKey: key,
                 args: args
               });
+            };
+            dispatchers[actionsKey][key] = dispatch;
+            actions[actionsKey][key] = (...args) => {
+              dispatch(...args);
             };
           }
         } else if (typeof handlers[key] === 'object') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-flux",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Tiny, simple wrapper around Facebook's Flux library.",
   "main": "index.js",
   "scripts": {

--- a/test/flux.js
+++ b/test/flux.js
@@ -440,4 +440,89 @@ describe('flux', () => {
     expect(didError).toBe(true);
   });
 
+  it('should allow dispatching to other actions', () => {
+
+    let hitServerSaveCount = 0;
+    let hitServerUpdateCount = 0;
+
+    let nextServerId = 0;
+
+    const createMessageActions = () => ({
+
+      draftAddMessage(dispatch) {
+        dispatch.to.addMessage();
+      },
+
+      draftUpdateMessage(dispatch, attrs) {
+        dispatch.to.updateMessage(attrs);
+      },
+
+      saveUpdateMessage(dispatch, attrs) {
+        dispatch.to.updateMessage(attrs);
+        if (attrs.id) {
+          hitServerUpdateCount++;
+        } else {
+          hitServerSaveCount++;
+          nextServerId++;
+          dispatch.to.updateMessage({id: nextServerId, cid: attrs.cid});
+        }
+      }
+    });
+
+    const createMessageStore = (store) => {
+
+      let nextId = 0;
+
+      store.setState({
+        messages: {}
+      });
+
+      return {
+        addMessage() {
+          nextId++;
+
+          store.setState({
+            messages: _.assign({}, store.state.messages, {
+              [nextId]: {
+                cid: nextId,
+                content: ''
+              }
+            })
+          });
+        },
+
+        updateMessage(attrs) {
+          store.setState({
+            messages: _.assign({}, store.state.messages, {
+              [attrs.cid]: _.assign({}, store.state.messages[attrs.cid], attrs)
+            })
+          });
+        }
+      };
+    };
+
+    const flux = Flux.create({
+      actions: {
+        message: createMessageActions
+      },
+      stores: {
+        message: createMessageStore
+      }
+    });
+
+    flux.actions.message.draftAddMessage();
+
+    flux.actions.message.draftUpdateMessage({cid: 1, content: 'Hell'});
+    expect(flux.stores.message.state.messages).toEqual({1: {cid: 1, content: 'Hell'}});
+
+    flux.actions.message.saveUpdateMessage({cid: 1, content: 'Hello!'});
+    expect(flux.stores.message.state.messages).toEqual({1: {cid: 1, id: 1, content: 'Hello!'}});
+
+    flux.actions.message.saveUpdateMessage({cid: 1, id: 1, content: 'Hello again!'});
+    expect(flux.stores.message.state.messages).toEqual({1: {cid: 1, id: 1, content: 'Hello again!'}});
+
+    expect(hitServerSaveCount).toEqual(1);
+    expect(hitServerUpdateCount).toEqual(1);
+  });
+
 });

--- a/test/flux.js
+++ b/test/flux.js
@@ -358,10 +358,10 @@ describe('flux', () => {
         dispatch(cid, content);
         data.addMessage(content)
           .then((result) => {
-            dispatch.actions.addMessageDone(cid, result.id);
+            dispatch.to.addMessageDone(cid, result.id);
           })
           .catch((error) => {
-            dispatch.actions.addMessageFail(cid, error);
+            dispatch.to.addMessageFail(cid, error);
           });
       }
     };
@@ -449,13 +449,9 @@ describe('flux', () => {
 
     const createMessageActions = () => ({
 
-      draftAddMessage(dispatch) {
-        dispatch.to.addMessage();
-      },
+      draftAddMessage: 'addMessage',
 
-      draftUpdateMessage(dispatch, attrs) {
-        dispatch.to.updateMessage(attrs);
-      },
+      draftUpdateMessage: 'updateMessage',
 
       saveUpdateMessage(dispatch, attrs) {
         dispatch.to.updateMessage(attrs);


### PR DESCRIPTION
@stevemolitor @bryanhelmig This is a tweak to add the ability for actions creators to dispatch to any action (within their namespace for now). Without this, you always have to dispatch to the same-named action, and that means that sometimes some unnecessary details leak into the stores. It also means that sometimes multiple action handlers have to exist in the store when otherwise one would suffice.

Take a look at the test to see an example. The store really just needs `addMessage` and `updateMessage`, but we don't actually want to call either one of those directly. The `dispatch.to.someActionName` lets you specify the action name for the dispatch.

Note also that implicit actions are bad here (since you can still call `addMessage` and `updateMessage` implicitly). I'm going to look at patching that up too, but I may leave that for another PR, since it's a breaking change.
